### PR TITLE
Update setup.py to remove broken requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='Labelbox & Databricks integration helper library',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=["labelbox", "pyspark", "databricks", "koalas"],
+    install_requires=["labelbox"],
     extras_require={
         'dev': ['pylint']
     }


### PR DESCRIPTION
The requirements in setup.py include pyspark, databricks and koalas. These packages are installed by default on Databricks. When running `%pip install labelspark` with the current setup it will install a different version of pyspark, databricks and koalas from Pypi. The package called databricks on Pypi is not the correct package and will overwrite the proper package on Databricks. This will cause `import labelspark` to fail with the error:

>ModuleNotFoundError: No module named 'databricks.koalas'

This 