### PR TITLE
Nl/debugging raph patch

### DIFF
--- a/labelspark/__init__.py
+++ b/labelspark/__init__.py
@@ -9,3 +9,4 @@ from .get_videoframe_annotations import get_videoframe_annotations
 from .is_json import is_json
 from .jsonToDataFrame import jsonToDataFrame
 from .spark_schema_to_string import spark_schema_to_string
+from .dictionary_collector import dictionary_collector

--- a/labelspark/bronze_to_silver.py
+++ b/labelspark/bronze_to_silver.py
@@ -1,13 +1,13 @@
 #this code block is needed for backwards compatibility with older Spark versions
 from pyspark import SparkContext
 from packaging import version
-sc = SparkContext.getOrCreate()
-if version.parse(sc.version) < version.parse("3.2.0"):
-  import databricks.koalas as pd
-  needs_koalas = True
-else:
-  import pyspark.pandas as pd
-  needs_koalas = False
+# sc = SparkContext.getOrCreate()
+# if version.parse(sc.version) < version.parse("3.2.0"):
+#   import databricks.koalas as pd
+#   needs_koalas = True
+# else:
+import pyspark.pandas as pd
+
 
 from labelspark.flatten_bronze_table import flatten_bronze_table
 from labelspark.add_json_answers_to_dictionary import add_json_answers_to_dictionary

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -7,6 +7,8 @@ import json
 from pyspark.sql.types import StructType, StructField, StringType, MapType, ArrayType
 from pyspark.sql.functions import udf, lit
 
+from labelspark.dictionary_collector import dictionary_collector
+
 def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), iam_integration='DEFAULT', metadata_index=False, **kwargs):
   """ Creates a Labelbox dataset and creates data rows given a spark dataframe. Uploads data rows in batches of 10,000.
   Args:
@@ -181,14 +183,11 @@ def create_data_row_uploads(spark_dataframe):
     }
   
   upload_list_df = spark_dataframe.select("uploads")
-  upload_list = upload_list_df.rdd.map(lambda row: return_as_dict(row))
-  upload_list = upload_list.collect()
+  my_collector = dictionary_collector()
+  upload_list = upload_list_df.rdd.map(lambda row: my_collector.return_as_dict(row)).collect()
   
   return upload_list
 
-  #trying to see if this fixes it 
-  def return_as_dict(row_object):
-    return row_object.asDict()
 
 def connect_spark_metadata(client, spark_dataframe, lb_metadata_index):
   """ Checks to make sure all desired metadata for upload has a corresponding field in Labelbox. Note limits on metadata field options, here https://docs.labelbox.com/docs/limits

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -59,7 +59,7 @@ def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), ia
       batch_df = pandas_df.iloc[i:]
     print(f'Batch Number {int(1+(i/upload_batch_size))} with {len(batch_df)} data rows')
     batch_upload = create_data_row_uploads(batch_df.to_spark())
-    task = lb_dataset.create_data_rows(batch)
+    task = lb_dataset.create_data_rows(batch_upload)
     task.wait_till_done() 
     print(f'Upload Time: {datetime.now()-starttime}')
     starttime = datetime.now()

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -44,7 +44,7 @@ def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), ia
   
   uploads_spark_dataframe = create_uploads_column(spark_dataframe, client, metadata_index)
   
-  pandas_df = uploads_spark_dataframe.to_pandas()
+  pandas_df = uploads_spark_dataframe.to_pandas_on_spark()
   
   upload_batch_size = 10000
   

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -182,7 +182,7 @@ def create_data_row_uploads(spark_dataframe, sc, spark):
   
   print(spark)
   upload_list_df = spark_dataframe.select("uploads")
-  print(upload_list_df.df1.sql_ctx.sparkSession)
+  print(upload_list_df.sql_ctx.sparkSession)
   upload_list = upload_list_df.rdd.map(lambda row: row.asDict())
   upload_list = upload_list.collect()
   

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -7,7 +7,7 @@ import json
 from pyspark.sql.types import StructType, StructField, StringType, MapType, ArrayType
 from pyspark.sql.functions import udf, lit
 
-def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), iam_integration='DEFAULT', metadata_index=False, sc=sc, **kwargs):
+def create_dataset(sc, client, spark_dataframe, dataset_name=str(datetime.now()), iam_integration='DEFAULT', metadata_index=False, **kwargs):
   """ Creates a Labelbox dataset and creates data rows given a spark dataframe. Uploads data rows in batches of 10,000.
   Args:
       client                  :     labelbox.Client object

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -192,11 +192,14 @@ def connect_spark_metadata(client, spark_dataframe, lb_metadata_index):
   Returns:
     Nothing - the metadata ontology has been updated
   """
+  mdo = client.get_data_row_metadata_ontology() #query Labelbox for metadata fields 
+  labelbox_metadata_names = [field['name'] for field in mdo._get_ontology()] #produce list of all metadata names in ontology
+  
   if lb_metadata_index:
     spark_metadata_names = list(lb_metadata_index.keys())
     for spark_metadata_name in spark_metadata_names:
-      mdo = client.get_data_row_metadata_ontology()
-      labelbox_metadata_names = [field['name'] for field in mdo._get_ontology()]
+#       mdo = client.get_data_row_metadata_ontology()
+#       labelbox_metadata_names = [field['name'] for field in mdo._get_ontology()]
       if spark_metadata_name not in labelbox_metadata_names:
         metadata_type = lb_metadata_index[spark_metadata_name]
         create_metadata_field(mdo, spark_dataframe, spark_metadata_name, metadata_type)

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -2,13 +2,12 @@ from labelbox.schema.data_row_metadata import DataRowMetadataKind as lb_metadata
 from pyspark import SparkContext
 from packaging import version
 from datetime import datetime
-import databricks.koalas as ks
 
 import json
 from pyspark.sql.types import StructType, StructField, StringType, MapType, ArrayType
 from pyspark.sql.functions import udf, lit
 
-def create_dataset(sc, client, spark_dataframe, dataset_name=str(datetime.now()), iam_integration='DEFAULT', metadata_index=False, **kwargs):
+def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), iam_integration='DEFAULT', metadata_index=False, **kwargs):
   """ Creates a Labelbox dataset and creates data rows given a spark dataframe. Uploads data rows in batches of 10,000.
   Args:
       client                  :     labelbox.Client object

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -1,6 +1,7 @@
 from labelbox.schema.data_row_metadata import DataRowMetadataKind as lb_metadata_type
 from packaging import version
 from datetime import datetime
+from pyspark.sql import SparkSession
 
 import json
 from pyspark.sql.types import StructType, StructField, StringType, MapType, ArrayType

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -151,7 +151,7 @@ def attach_metadata(metadata_value, data_row, column_name, mdo_lookup_bytes, met
   elif metadata_value is not None:
     data_row['metadata_fields'].append({
       "schema_id" : mdo_lookup[column_name],
-      "value" : metadata_value
+      "value" : str(metadata_value)
     })
   return data_row
 

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -180,7 +180,8 @@ def create_data_row_uploads(spark_dataframe, sc, spark):
       "metadata_fields" : pyspark_row.uploads.metadata_fields
     }
   
-  SparkSession.getActiveSession() #trying different things to guarantee we aren't trying to create new stuff on executors
+  print(sc) #what is the spark context 
+  print(spark)
   upload_list_df = spark_dataframe.select("uploads")
   upload_list = upload_list_df.rdd.map(lambda row: row.asDict())
   upload_list = upload_list.collect()

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -179,7 +179,8 @@ def create_data_row_uploads(spark_dataframe, sc):
       "metadata_fields" : pyspark_row.uploads.metadata_fields
     }
   
-  upload_list = spark_dataframe.select("uploads").rdd.map(lambda x: x.uploads.asDict()).collect()
+  upload_list_df = spark_dataframe.select("uploads") #trying to figure out where the bug is 
+  upload_list = upload_list_df.rdd.map(lambda x: x.uploads.asDict()).collect()
   
   return upload_list
 

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -183,8 +183,8 @@ def create_data_row_uploads(spark_dataframe):
     }
   
   upload_list_df = spark_dataframe.select("uploads")
-  my_collector = dictionary_collector()
-  upload_list = upload_list_df.rdd.map(lambda row: my_collector.return_as_dict(row)).collect()
+ # my_collector = dictionary_collector()
+  upload_list = upload_list_df.rdd.map(lambda row: row.asDict()).collect()
   
   return upload_list
 

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -62,6 +62,7 @@ def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), ia
     else:
       batch = uploads_list[i:]
       print(f'Batch {int(1+(i/upload_batch_size))}, {len(batch)} data rows')
+      print(batch) #DEBUG
     task = lb_dataset.create_data_rows(batch)  
     task.wait_till_done()  
     print(f'Upload Time: {datetime.now()-starttime}')

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -14,7 +14,7 @@ import json
 from pyspark.sql.types import StructType, StructField, StringType, MapType, ArrayType
 from pyspark.sql.functions import udf, lit
 
-def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), iam_integration='DEFAULT', metadata_index=False, context=sc, connector=spark, **kwargs):
+def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), iam_integration='DEFAULT', metadata_index=False, sc=sc, spark=spark, **kwargs):
   """ Creates a Labelbox dataset and creates data rows given a spark dataframe. Uploads data rows in batches of 10,000.
   Args:
       client                  :     labelbox.Client object
@@ -51,7 +51,7 @@ def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), ia
   
   uploads_spark_dataframe = create_uploads_column(spark_dataframe, client, metadata_index)
   
-  uploads_list = create_data_row_uploads(uploads_spark_dataframe)
+  uploads_list = create_data_row_uploads(uploads_spark_dataframe, sc)
   
   print(f'Uploading {len(uploads_list)} to Labelbox in dataset with ID {lb_dataset.uid}')
   
@@ -163,7 +163,7 @@ def attach_metadata(metadata_value, data_row, column_name, mdo_lookup_bytes, met
     })
   return data_row
 
-def create_data_row_uploads(spark_dataframe):
+def create_data_row_uploads(spark_dataframe, sc):
   """ Function to-be-wrapped into a user-defined function
   Args:
       metadata_value          :     Value for the metadata field

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -2,19 +2,12 @@ from labelbox.schema.data_row_metadata import DataRowMetadataKind as lb_metadata
 from pyspark import SparkContext
 from packaging import version
 from datetime import datetime
-sc = SparkContext.getOrCreate()
-if version.parse(sc.version) < version.parse("3.2.0"):
-  import databricks.koalas as pd
-  needs_koalas = True
-else:
-  import pyspark.pandas as pd
-  needs_koalas = False  
 
 import json
 from pyspark.sql.types import StructType, StructField, StringType, MapType, ArrayType
 from pyspark.sql.functions import udf, lit
 
-def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), iam_integration='DEFAULT', metadata_index=False, sc=sc, spark=spark, **kwargs):
+def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), iam_integration='DEFAULT', metadata_index=False, sc=sc, **kwargs):
   """ Creates a Labelbox dataset and creates data rows given a spark dataframe. Uploads data rows in batches of 10,000.
   Args:
       client                  :     labelbox.Client object

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -62,7 +62,6 @@ def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), ia
     else:
       batch = uploads_list[i:]
       print(f'Batch {int(1+(i/upload_batch_size))}, {len(batch)} data rows')
-      print(batch) #DEBUG
     task = lb_dataset.create_data_rows(batch)  
     task.wait_till_done()  
     print(f'Upload Time: {datetime.now()-starttime}')

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -179,6 +179,7 @@ def create_data_row_uploads(spark_dataframe, sc, spark):
       "metadata_fields" : pyspark_row.uploads.metadata_fields
     }
   
+  SparkSession.getActiveSession() #trying different things to guarantee we aren't trying to create new stuff on executors
   upload_list_df = spark_dataframe.select("uploads")
   upload_list = upload_list_df.rdd.map(lambda row: row.asDict())
   upload_list = upload_list.collect()

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -184,8 +184,7 @@ def create_data_row_uploads(spark_dataframe):
     }
   
   upload_list_df = spark_dataframe.select("uploads")
- # my_collector = dictionary_collector()
-  upload_list = upload_list_df.rdd.map(lambda row: row.asDict()).collect()
+  upload_list = upload_list_df.rdd.map(lambda row: row.uploads.asDict()).collect()
   
   return upload_list
 

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -53,7 +53,7 @@ def create_dataset(client, spark_dataframe, dataset_name=str(datetime.now()), ia
   print(f'Uploading {len(pandas_df)} to Labelbox in dataset with ID {lb_dataset.uid}')
   
   for i in range(0, len(pandas_df), upload_batch_size):
-    if i+upload_batch_size<=len(uploads_list):
+    if i+upload_batch_size<=len(pandas_df):
       batch_df = pandas_df.iloc[i:i+upload_batch_size]
     else:
       batch_df = pandas_df.iloc[i:]

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -1,5 +1,4 @@
 from labelbox.schema.data_row_metadata import DataRowMetadataKind as lb_metadata_type
-from pyspark import SparkContext
 from packaging import version
 from datetime import datetime
 
@@ -180,11 +179,7 @@ def create_data_row_uploads(spark_dataframe, sc):
       "metadata_fields" : pyspark_row.uploads.metadata_fields
     }
   
-  list_of_values = spark_dataframe.select("uploads").cache().collect()
-  
-  rdd_list = sc.parallelize(list_of_values)
-  
-  upload_list = rdd_list.rdd.map(lambda x: x.asDict())
+  upload_list = spark_dataframe.select("uploads").rdd.map(lambda x: x.uploads.asDict()).collect()
   
   return upload_list
 

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -180,7 +180,8 @@ def create_data_row_uploads(spark_dataframe, sc, spark):
     }
   
   upload_list_df = spark_dataframe.select("uploads")
-  upload_list = upload_list_df.rdd.map(lambda x: x.uploads.asDict()).collect() 
+  upload_list = upload_list_df.rdd.map(lambda row: row.asDict())
+  upload_list = upload_list.collect()
   
   return upload_list
 

--- a/labelspark/create_dataset.py
+++ b/labelspark/create_dataset.py
@@ -180,9 +180,9 @@ def create_data_row_uploads(spark_dataframe, sc, spark):
       "metadata_fields" : pyspark_row.uploads.metadata_fields
     }
   
-  print(sc) #what is the spark context 
   print(spark)
   upload_list_df = spark_dataframe.select("uploads")
+  print(upload_list_df.df1.sql_ctx.sparkSession)
   upload_list = upload_list_df.rdd.map(lambda row: row.asDict())
   upload_list = upload_list.collect()
   

--- a/labelspark/dictionary_collector.py
+++ b/labelspark/dictionary_collector.py
@@ -1,0 +1,5 @@
+class dictionary_collector:
+  
+  @staticmethod
+  def return_as_dict(row_object):
+    return row_object.asDict()

--- a/labelspark/get_videoframe_annotations.py
+++ b/labelspark/get_videoframe_annotations.py
@@ -4,13 +4,13 @@ import json
 #this code block is needed for backwards compatibility with older Spark versions
 from pyspark import SparkContext
 from packaging import version
-sc = SparkContext.getOrCreate()
-if version.parse(sc.version) < version.parse("3.2.0"):
-  import databricks.koalas as pd
-  needs_koalas = True
-else:
-  import pyspark.pandas as pd
-  needs_koalas = False
+# sc = SparkContext.getOrCreate()
+# if version.parse(sc.version) < version.parse("3.2.0"):
+#   import databricks.koalas as pd
+#   needs_koalas = True
+# else:
+import pyspark.pandas as pd
+needs_koalas = False
 
 from labelspark.jsonToDataFrame import jsonToDataFrame
 


### PR DESCRIPTION
Tested with a dataframe with and without metadata. 

We might want to consider suppressing the print statements in create_dataset, but this actually is helpful feedback to the user to show that datarows are actually being sent (and not hanging for minutes). Let's gather customer feedback on that and calibrate later. 