### PR TITLE
Removed reference to needs_koalas from bronze_to_silver method 

### DIFF
--- a/labelspark/bronze_to_silver.py
+++ b/labelspark/bronze_to_silver.py
@@ -1,11 +1,6 @@
 #this code block is needed for backwards compatibility with older Spark versions
 from pyspark import SparkContext
 from packaging import version
-# sc = SparkContext.getOrCreate()
-# if version.parse(sc.version) < version.parse("3.2.0"):
-#   import databricks.koalas as pd
-#   needs_koalas = True
-# else:
 import pyspark.pandas as pd
 
 
@@ -24,10 +19,7 @@ def bronze_to_silver(bronze_table):
     if video:
         bronze_table = bronze_table.withColumnRenamed("Label.frameNumber",
                                                       "frameNumber")
-    if needs_koalas:
-        bronze_table = bronze_table.to_koalas()
-    else:
-        bronze_table = bronze_table.to_pandas_on_spark()
+    bronze_table = bronze_table.to_pandas_on_spark()
 
     new_json = []
     for index, row in bronze_table.iterrows():


### PR DESCRIPTION
We removed needs_koalas and Spark version checking but left a reference to the variable in code. Removed it.